### PR TITLE
Rank 1 was left out. Bring it back.

### DIFF
--- a/src/h5_lt.hpp
+++ b/src/h5_lt.hpp
@@ -1645,7 +1645,7 @@ namespace NodeHDF5 {
             }
             args.GetReturnValue().Set(array);
             H5Tclose(basetype_id);
-          } else if (rank > 1 && values_dim.get()[0] > 0) {
+          } else if (rank >= 1 && values_dim.get()[0] > 0) {
             hid_t                   dataspace_id = H5S_ALL;
             hid_t                   memspace_id  = H5S_ALL;
             size_t                  typeSize     = H5Tget_size(t);


### PR DESCRIPTION
A commit in Oct 13, 2019 changed the original rank == 1 comparison to rank > 1. The code segment applies to both situations so we should make it rank >= 1. 

This change will remove the bug where a rank 1 array of strings gets read as a single fixed length string.